### PR TITLE
DbHelper Quick Fix

### DIFF
--- a/app/src/main/java/classact/com/xprize/MainActivity.java
+++ b/app/src/main/java/classact/com/xprize/MainActivity.java
@@ -91,7 +91,7 @@ public class MainActivity extends AppCompatActivity {
                     // Play intro movie
                     intent = new Intent(this, Movie.class);
                     intent.putExtra(Code.RES_NAME, u.getUnitFirstTimeMovieFile());
-                    intent.putExtra(Code.SHOW_MV_BUTTONS, false);
+                    intent.putExtra(Code.SHOW_MV_BUTTONS, true);
                     intent.putExtra(Code.NEXT_BG_CODE, Code.INTRO);
                     resultCode = Code.INTRO;
 
@@ -213,7 +213,7 @@ public class MainActivity extends AppCompatActivity {
                     // Play ending movie
                     intent = new Intent(this, Movie.class);
                     intent.putExtra(Code.RES_NAME, u.getUnitFirstTimeMovieFile());
-                    intent.putExtra(Code.SHOW_MV_BUTTONS, false);
+                    intent.putExtra(Code.SHOW_MV_BUTTONS, true);
                     intent.putExtra(Code.NEXT_BG_CODE, Code.FINALE);
                     resultCode = Code.FINALE;
                 }

--- a/app/src/main/java/classact/com/xprize/database/DbHelper.java
+++ b/app/src/main/java/classact/com/xprize/database/DbHelper.java
@@ -63,7 +63,7 @@ public class DbHelper extends SQLiteAssetHelper {
 		boolean dbExist = checkDatabase();
 		if(dbExist){
 			// do nothing here, the database exists already
-			copyDatabase();
+			// copyDatabase();
 		}else{
 			//by doing this we will be able to copy our existing db over the blank db that is
 			//created when the app first ran


### PR DESCRIPTION
Fix DBHelper - don't enabled 'copyDatabase' when calling 'createDatabase' (non-parameterized) method.

Enable Pause Buttton for Intro and Finale ... until I get the silly bug fixed